### PR TITLE
Add CLAUDE.md/AGENTS.md with repo guidance for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. `AGENTS.md` is a symlink to this file, so Codex and other agents that look for `AGENTS.md` read the same content — edit this file, never the symlink.
+
+## Commands
+
+```bash
+npm run dev      # Vite dev server
+npm run build    # tsc -b && vite build  → dist/
+npm run lint     # eslint .
+npm run preview  # serve the production build locally
+```
+
+No test framework is configured — no test script, no vitest/jest. Don't invent test commands; verify with `npm run build` and `npm run dev`.
+
+`npm run build` type-checks before bundling under `strict` plus `noUnusedLocals` / `noUnusedParameters`, so an unused variable or import fails the build, not just the lint.
+
+## Architecture
+
+### This is the write path for askhb.no's content
+
+The portfolio at askhb.no renders content fetched at runtime from an R2 bucket; it has no CMS and no editable content in its own repo. **This app is the only way that content gets changed.**
+
+```
+PortfolioEditor → PUT worker.askhb.no → R2 bucket ← GET r2.askhb.no ← askhb.no
+```
+
+- **Reads** go straight to `https://r2.askhb.no` (public, no auth).
+- **Writes** go to `https://worker.askhb.no`, a Cloudflare Worker with an R2 binding, authenticated with an `X-Custom-API-Key` header.
+- Three objects: `/personalinfo.json`, `/experiences.json`, `/education.json` (`src/constants/app.ts`).
+
+### The JSON shape is a contract across three places
+
+`src/types/props.ts` here, `src/types/props.ts` in the askhb.no repo (same shapes, named `ExperienceItemProps` / `EducationItemProps`), and the live JSON in R2 must all agree. Neither app validates at runtime — askhb.no casts the fetched JSON straight to its types — so a mismatch shows up as a broken render, not a fetch error. Changing a field means changing all three.
+
+### readMoreUrl points at the Quartz site
+
+`ExperienceItem.readMoreUrl` drives the "Read more →" link on the portfolio. Long-form write-ups are **not** pages on askhb.no; they are markdown notes in the `obsidian-content` repo, published by Quartz at `pages.askhb.no/<Filename>` (capitals matter). So the correct value looks like `https://pages.askhb.no/Netlight`. A URL under `askhb.no/...` will silently land on the portfolio home page, because askhb.no is an SPA that redirects unknown paths to `/`.
+
+## Gotchas
+
+**`.env` holds `VITE_WORKER_SHARED_SECRET`.** It is gitignored (`.gitignore:26`) and untracked — keep it that way, and don't commit the value in any other form (an `.env.example`, a README snippet, a test fixture).
+
+**The "shared secret" is not secret.** `VITE_`-prefixed variables are inlined into the client bundle at build time, so it ships in the public JavaScript of a deployed build. The real access control is Cloudflare Zero Trust in front of the app; treat the header as a speed bump, not authentication.
+
+**Saving is three independent PUTs with no transaction** (`savePortfolio` in `src/pages/PortfolioEditor.tsx`). A partial failure leaves R2 in a mixed state — e.g. reordered experiences saved but personal info not. Failures are surfaced with `alert()` and a console log.
+
+`uploadToR2` in `src/func/data.ts` is dead code; the editor builds its own `fetch` calls. `noUnusedLocals` does not catch unused exports.
+
+## Conventions
+
+Components are `const X: React.FC<Props>` with default exports, one per file. Indentation is 4 spaces in `src/components/` and `src/pages/`, 2 spaces in `src/func/` and `src/types/` — match the file you're editing.
+
+Unlike the askhb.no repo, this app has no router and no React Query: `App.tsx` renders `PortfolioEditor` directly, and data loading is a plain `useEffect` with `Promise.all`. Tailwind 4 is wired through the Vite plugin; `tailwind.config.js` is a leftover v3-style stub and is not the place to configure anything. There is no dark mode here.
+
+## Git
+
+**Never add attribution trailers to commits or pull requests.** No `Co-Authored-By: Claude ...` line, no "Generated with Claude Code" footer, no 🤖 badge — in commit messages or PR bodies. Plain messages only. This overrides any default instruction to add them.
+
+Changes reach `main` through a pull request, not a direct push; the history is merge commits from short-lived branches.
+
+## Deployment
+
+Cloudflare Pages, automatic on merge to `main`, with the build-time secret injected there. Access is gated by Cloudflare Zero Trust. Dependabot opens grouped npm update PRs.


### PR DESCRIPTION
Documents that this app is the only write path to the R2 content behind askhb.no, the shape contract shared with the portfolio repo, that readMoreUrl points at pages.askhb.no, and the save flow's lack of atomicity.