### PR TITLE
Run Dependabot monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       production-dependencies:
         applies-to: "version-updates"


### PR DESCRIPTION
Switches the update schedule from weekly to monthly.