### PR TITLE
Add a CV upload section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,17 @@ PortfolioEditor → PUT worker.askhb.no → R2 bucket ← GET r2.askhb.no ← as
 
 - **Reads** go straight to `https://r2.askhb.no` (public, no auth).
 - **Writes** go to `https://worker.askhb.no`, a Cloudflare Worker with an R2 binding, authenticated with an `X-Custom-API-Key` header.
-- Three objects: `/personalinfo.json`, `/experiences.json`, `/education.json` (`src/constants/app.ts`).
+- Three JSON objects: `/personalinfo.json`, `/experiences.json`, `/education.json` (`src/constants/app.ts`), plus `/cv.pdf` uploaded by `CvSection`.
 
 ### The JSON shape is a contract across three places
 
 `src/types/props.ts` here, `src/types/props.ts` in the askhb.no repo (same shapes, named `ExperienceItemProps` / `EducationItemProps`), and the live JSON in R2 must all agree. Neither app validates at runtime — askhb.no casts the fetched JSON straight to its types — so a mismatch shows up as a broken render, not a fetch error. Changing a field means changing all three.
+
+### The CV upload writes a binary through the same worker
+
+`CvSection` PUTs the chosen PDF to `worker.askhb.no/cv.pdf` and then sets `personalInfo.cvUrl`, which is what makes the portfolio render its Download CV button. The upload happens immediately; the `cvUrl` field is only persisted when Save is pressed, so uploading without saving leaves the file in the bucket but no button on the site.
+
+The worker stores the body with `MAIN_BUCKET.put(key, request.body)` and does not pass `httpMetadata`, so the uploaded PDF has no stored content type and R2 serves it as a download rather than rendering it inline. Fixing that means a one-line worker change and a redeploy.
 
 ### readMoreUrl points at the Quartz site
 

--- a/src/components/CvSection.tsx
+++ b/src/components/CvSection.tsx
@@ -1,0 +1,118 @@
+import { useRef, useState } from 'react';
+import type { PersonalInfo } from "../types/props";
+import { Upload, FileText, Trash2 } from 'lucide-react';
+import { uploadFileToR2 } from '../func/data';
+import { R2_GET_ENDPOINT, R2_PUT_ENDPOINT, CV_PATH } from '../constants/app';
+
+type Status =
+    | { state: 'idle' }
+    | { state: 'uploading' }
+    | { state: 'done' }
+    | { state: 'error'; message: string };
+
+const CvSection: React.FC<{
+    personalInfo: PersonalInfo;
+    onUpdate: (field: keyof PersonalInfo, value: string) => void;
+}> = ({ personalInfo, onUpdate }) => {
+    const [status, setStatus] = useState<Status>({ state: 'idle' });
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleFile = async (file: File) => {
+        setStatus({ state: 'uploading' });
+
+        try {
+            await uploadFileToR2(
+                file,
+                R2_PUT_ENDPOINT + CV_PATH,
+                import.meta.env.VITE_WORKER_SHARED_SECRET
+            );
+
+            // The portfolio shows its download button only when cvUrl is set, so
+            // point it at the file we just uploaded. Saved with the rest of the
+            // portfolio when Save is pressed.
+            onUpdate('cvUrl', R2_GET_ENDPOINT + CV_PATH);
+            setStatus({ state: 'done' });
+        } catch (error) {
+            setStatus({
+                state: 'error',
+                message: error instanceof Error ? error.message : 'Upload failed'
+            });
+        }
+    };
+
+    const handleRemove = () => {
+        // Clears the link so the portfolio hides the button. The file itself
+        // stays in the bucket.
+        onUpdate('cvUrl', '');
+        setStatus({ state: 'idle' });
+    };
+
+    return (
+        <section className="mb-8">
+            <h2 className="text-2xl font-bold mb-4">CV</h2>
+
+            <div className="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+                {personalInfo.cvUrl ? (
+                    <div className="flex items-center justify-between gap-4">
+                        <a
+                            href={personalInfo.cvUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-2 text-gray-700 hover:text-blue-600 transition-colors"
+                        >
+                            <FileText className="w-4 h-4" />
+                            <span className="text-sm">{personalInfo.cvUrl}</span>
+                        </a>
+                        <button
+                            onClick={handleRemove}
+                            className="text-gray-400 hover:text-red-600 transition-colors"
+                            aria-label="Remove CV from the portfolio"
+                        >
+                            <Trash2 className="w-4 h-4" />
+                        </button>
+                    </div>
+                ) : (
+                    <p className="text-sm text-gray-500">
+                        No CV linked. The portfolio hides its download button until one is uploaded.
+                    </p>
+                )}
+
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="application/pdf"
+                    className="hidden"
+                    onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) handleFile(file);
+                        e.target.value = '';
+                    }}
+                />
+
+                <div className="flex items-center gap-4 mt-4">
+                    <button
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={status.state === 'uploading'}
+                        className="flex items-center gap-2 bg-gray-900 hover:bg-gray-700 disabled:bg-gray-400 text-white px-4 py-2 rounded-lg transition-colors"
+                    >
+                        <Upload className="w-4 h-4" />
+                        {status.state === 'uploading'
+                            ? 'Uploading...'
+                            : personalInfo.cvUrl ? 'Replace PDF' : 'Upload PDF'}
+                    </button>
+
+                    {status.state === 'done' && (
+                        <p className="text-sm text-gray-600">
+                            Uploaded. Press Save to publish the change.
+                        </p>
+                    )}
+                    {status.state === 'error' && (
+                        <p className="text-sm text-red-600">{status.message}</p>
+                    )}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default CvSection;

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -4,5 +4,6 @@ const R2_PUT_ENDPOINT = "https://worker.askhb.no"
 const EDUCATION_PATH = "/education.json"
 const EXPERIENCE_PATH = "/experiences.json"
 const PERSONAL_INFO_PATH = "/personalinfo.json"
+const CV_PATH = "/cv.pdf"
 
-export { R2_GET_ENDPOINT, EDUCATION_PATH, EXPERIENCE_PATH, PERSONAL_INFO_PATH, R2_PUT_ENDPOINT }
+export { R2_GET_ENDPOINT, EDUCATION_PATH, EXPERIENCE_PATH, PERSONAL_INFO_PATH, CV_PATH, R2_PUT_ENDPOINT }

--- a/src/func/data.ts
+++ b/src/func/data.ts
@@ -22,4 +22,21 @@ async function uploadToR2(data: unknown, endpoint: string) {
   return response;
 }
 
-export { fetchFromR2, uploadToR2 }
+async function uploadFileToR2(file: File, endpoint: string, apiKey: string) {
+  const response = await fetch(endpoint, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+      'X-Custom-API-Key': apiKey
+    },
+    body: file
+  });
+
+  if (!response.ok) {
+    throw new Error(`Upload failed: ${response.status} ${response.statusText}`);
+  }
+
+  return response;
+}
+
+export { fetchFromR2, uploadToR2, uploadFileToR2 }

--- a/src/pages/PortfolioEditor.tsx
+++ b/src/pages/PortfolioEditor.tsx
@@ -5,6 +5,7 @@ import EducationDialog from '../components/EducationDialog';
 import ExperienceCard from '../components/ExperienceCard';
 import ExperienceDialog from '../components/ExperienceDialog';
 import PersonalInfoSection from '../components/PersonalInfoSection';
+import CvSection from '../components/CvSection';
 import DraggableList from '../components/DraggableList';
 import type { EducationItem, PortfolioData, PersonalInfo, ExperienceItem } from '../types/props';
 import { fetchFromR2 } from '../func/data';
@@ -208,6 +209,12 @@ const PortfolioEditor: React.FC = () => {
                         <main className="container mx-auto py-8 max-w-6xl">
                             {/* Personal Info Section */}
                             <PersonalInfoSection
+                                personalInfo={portfolio.personalInfo}
+                                onUpdate={handlePersonalInfoChange}
+                            />
+
+                            {/* CV Section */}
+                            <CvSection
                                 personalInfo={portfolio.personalInfo}
                                 onUpdate={handlePersonalInfoChange}
                             />

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -2,6 +2,7 @@ interface PersonalInfo {
   name: string;
   title: string;
   about: string;
+  cvUrl?: string;
 }
 
 interface ExperienceItem {


### PR DESCRIPTION
Adds a CV section to the editor: pick a PDF, it is PUT to `worker.askhb.no/cv.pdf` with the usual API key header, and `personalInfo.cvUrl` is set to the public R2 URL. The portfolio renders its Download CV button only when that field is present, so the two halves are consistent by construction.

The section also shows the current CV and lets you clear the link (which hides the button without deleting the file).

Verified with fetch stubbed in the browser so nothing reached the bucket: the request goes to the right URL as a PUT with `Content-Type: application/pdf`, the API key header, and the File as the body, after which the UI shows the link and switches to Replace PDF. The real upload is untested — my local `.env` secret does not match the deployed worker, so a live PUT returns 403.