### PR TITLE
Refuse to save until the portfolio has loaded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ The worker stores the body with `MAIN_BUCKET.put(key, request.body)` and does no
 
 **Saving is three independent PUTs with no transaction** (`savePortfolio` in `src/pages/PortfolioEditor.tsx`). A partial failure leaves R2 in a mixed state — e.g. reordered experiences saved but personal info not. Failures are surfaced with `alert()` and a console log.
 
+**Saving is gated on a successful load, and must stay that way.** The editor's initial state is empty (`{name:'',title:'',about:''}`, `[]`, `[]`). If it saves before the fetch resolves or after it fails, it PUTs that empty state over all three files, and R2 has no versioning and the worker no DELETE — the content is gone. Both the Save button and `savePortfolio` itself check `isLoading || loadError`, and the editor body renders only when neither is set. Don't remove any of the three.
+
 `uploadToR2` in `src/func/data.ts` is dead code; the editor builds its own `fetch` calls. `noUnusedLocals` does not catch unused exports.
 
 ## Conventions

--- a/src/pages/PortfolioEditor.tsx
+++ b/src/pages/PortfolioEditor.tsx
@@ -116,6 +116,14 @@ const PortfolioEditor: React.FC = () => {
     };
     
     const savePortfolio = async () => {
+        // Never write the empty initial state over the bucket. Without this the
+        // editor would PUT blank strings and empty arrays over every entry if it
+        // saved before the load finished or after it failed, and R2 keeps no
+        // versions to restore from.
+        if (isLoading || loadError) {
+            return;
+        }
+
         try {
             const headers = {
                 'Content-Type': 'application/json',
@@ -182,7 +190,13 @@ const PortfolioEditor: React.FC = () => {
                         <h1 className="text-3xl font-bold">Portfolio Editor</h1>
                         <button
                             onClick={savePortfolio}
-                            className="flex items-center gap-2 px-6 py-3 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
+                            disabled={isLoading || !!loadError}
+                            title={
+                                isLoading ? 'Waiting for the portfolio to load'
+                                    : loadError ? 'Cannot save: the portfolio failed to load'
+                                    : undefined
+                            }
+                            className="flex items-center gap-2 px-6 py-3 bg-gray-900 text-white rounded-lg hover:bg-gray-800 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
                         >
                             <Save className="w-5 h-5" />
                             Save Portfolio
@@ -204,7 +218,10 @@ const PortfolioEditor: React.FC = () => {
                     </div>
                 )}
 
-                {!isLoading && (
+                {/* Only render the editor once real data is in. On a load failure
+                    the state is still the empty initial value, and showing that as
+                    if it were the portfolio invites the user to save over it. */}
+                {!isLoading && !loadError && (
                     <>
                         <main className="container mx-auto py-8 max-w-6xl">
                             {/* Personal Info Section */}


### PR DESCRIPTION
Found during review. The editor's initial state is `{personalInfo:{name:'',title:'',about:''}, experiences:[], education:[]}`, and the Save button sat outside the `{!isLoading && (` gate with no `disabled` prop and no reference to `loadError`. Two one-click paths wrote that empty state over every file:

- Clicking Save before the initial fetch resolved.
- Any one of the three GETs failing — `finally` sets `isLoading=false`, so the full editor rendered populated with the empty initial state next to the red error banner.

R2 has no object versioning here and the worker exposes no DELETE, so either one destroyed all content irrecoverably.

Three changes: `disabled={isLoading || !!loadError}` on the button with an explanatory title, the same check inside `savePortfolio` so a future caller cannot bypass it, and the editor body now renders only on `!isLoading && !loadError`.

Verified by pointing the read endpoint at a dead host: error banner shows, editor body does not render, Save is disabled, and clicking it attempts **zero** PUTs (checked with fetch instrumented). Restored the endpoint and confirmed the healthy path is unchanged — editor renders, Save enabled, all 10 entries load.