### PR TITLE
Fix the CV replace path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,13 @@ PortfolioEditor → PUT worker.askhb.no → R2 bucket ← GET r2.askhb.no ← as
 
 ### The CV upload writes a binary through the same worker
 
-`CvSection` PUTs the chosen PDF to `worker.askhb.no/cv.pdf` and then sets `personalInfo.cvUrl`, which is what makes the portfolio render its Download CV button. The upload happens immediately; the `cvUrl` field is only persisted when Save is pressed, so uploading without saving leaves the file in the bucket but no button on the site.
+`CvSection` PUTs the chosen PDF to `worker.askhb.no/cv.pdf` and then sets `personalInfo.cvUrl`, which is what makes the portfolio render its Download CV button.
 
-The worker stores the body with `MAIN_BUCKET.put(key, request.body)` and does not pass `httpMetadata`, so the uploaded PDF has no stored content type and R2 serves it as a download rather than rendering it inline. Fixing that means a one-line worker change and a redeploy.
+**Uploading is itself a publish, for every upload after the first.** The key is always `/cv.pdf`, so once `cvUrl` points there, a replacement is live the moment the PUT returns — Save only updates the link. Save still matters, because `cvUrl` carries a `?v=<timestamp>` cache buster: `r2.askhb.no` serves the PDF with `max-age=14400`, so without a fresh query string a replacement stays hidden behind the edge cache for up to 4 hours.
+
+Each upload takes a ticket from a `useRef` counter and only the newest may write state. Without it, a slow upload landing after the user removed the CV would silently set `cvUrl` again. The remove button is also disabled while an upload is in flight. Don't drop either guard.
+
+Removing only clears `cvUrl`; the PDF stays in the bucket and remains publicly reachable at its URL. The worker supports no DELETE, so there is no way to take a CV offline from this UI.
 
 ### readMoreUrl points at the Quartz site
 

--- a/src/components/CvSection.tsx
+++ b/src/components/CvSection.tsx
@@ -16,8 +16,16 @@ const CvSection: React.FC<{
 }> = ({ personalInfo, onUpdate }) => {
     const [status, setStatus] = useState<Status>({ state: 'idle' });
     const fileInputRef = useRef<HTMLInputElement>(null);
+    // Every upload takes a ticket. Only the newest one is allowed to write state,
+    // so a slow request that finishes after a newer upload — or after the user
+    // removed the CV — cannot resurrect a link or report a stale result.
+    const latestUpload = useRef(0);
+
+    const isUploading = status.state === 'uploading';
+    const hasCv = !!personalInfo.cvUrl;
 
     const handleFile = async (file: File) => {
+        const ticket = ++latestUpload.current;
         setStatus({ state: 'uploading' });
 
         try {
@@ -27,12 +35,17 @@ const CvSection: React.FC<{
                 import.meta.env.VITE_WORKER_SHARED_SECRET
             );
 
-            // The portfolio shows its download button only when cvUrl is set, so
-            // point it at the file we just uploaded. Saved with the rest of the
-            // portfolio when Save is pressed.
-            onUpdate('cvUrl', R2_GET_ENDPOINT + CV_PATH);
+            if (ticket !== latestUpload.current) return;
+
+            // Every upload overwrites the same key, and r2.askhb.no serves it with
+            // a 4 hour max-age, so without a changing query string a replacement
+            // stays invisible behind the edge cache. The portfolio also shows its
+            // download button only when cvUrl is set.
+            onUpdate('cvUrl', `${R2_GET_ENDPOINT}${CV_PATH}?v=${Date.now()}`);
             setStatus({ state: 'done' });
         } catch (error) {
+            if (ticket !== latestUpload.current) return;
+
             setStatus({
                 state: 'error',
                 message: error instanceof Error ? error.message : 'Upload failed'
@@ -41,8 +54,12 @@ const CvSection: React.FC<{
     };
 
     const handleRemove = () => {
+        // Invalidate any upload still in flight, otherwise it would set cvUrl again
+        // when it lands and undo this.
+        latestUpload.current++;
+
         // Clears the link so the portfolio hides the button. The file itself
-        // stays in the bucket.
+        // stays in the bucket and remains publicly reachable at its URL.
         onUpdate('cvUrl', '');
         setStatus({ state: 'idle' });
     };
@@ -65,7 +82,9 @@ const CvSection: React.FC<{
                         </a>
                         <button
                             onClick={handleRemove}
-                            className="text-gray-400 hover:text-red-600 transition-colors"
+                            disabled={isUploading}
+                            title={isUploading ? 'Wait for the upload to finish' : 'Remove the CV link from the portfolio'}
+                            className="text-gray-400 hover:text-red-600 disabled:text-gray-300 disabled:cursor-not-allowed transition-colors"
                             aria-label="Remove CV from the portfolio"
                         >
                             <Trash2 className="w-4 h-4" />
@@ -73,7 +92,9 @@ const CvSection: React.FC<{
                     </div>
                 ) : (
                     <p className="text-sm text-gray-500">
-                        No CV linked. The portfolio hides its download button until one is uploaded.
+                        No CV linked. The portfolio hides its download button until one is
+                        uploaded. Note that an uploaded PDF is publicly reachable at its URL
+                        whether or not it is linked.
                     </p>
                 )}
 
@@ -92,18 +113,17 @@ const CvSection: React.FC<{
                 <div className="flex items-center gap-4 mt-4">
                     <button
                         onClick={() => fileInputRef.current?.click()}
-                        disabled={status.state === 'uploading'}
-                        className="flex items-center gap-2 bg-gray-900 hover:bg-gray-700 disabled:bg-gray-400 text-white px-4 py-2 rounded-lg transition-colors"
+                        disabled={isUploading}
+                        className="flex items-center gap-2 bg-gray-900 hover:bg-gray-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg transition-colors"
                     >
                         <Upload className="w-4 h-4" />
-                        {status.state === 'uploading'
-                            ? 'Uploading...'
-                            : personalInfo.cvUrl ? 'Replace PDF' : 'Upload PDF'}
+                        {isUploading ? 'Uploading...' : hasCv ? 'Replace PDF' : 'Upload PDF'}
                     </button>
 
                     {status.state === 'done' && (
                         <p className="text-sm text-gray-600">
-                            Uploaded. Press Save to publish the change.
+                            Uploaded. The file is already public; press Save so the
+                            site links this version instead of a cached one.
                         </p>
                     )}
                     {status.state === 'error' && (

--- a/src/func/data.ts
+++ b/src/func/data.ts
@@ -33,7 +33,10 @@ async function uploadFileToR2(file: File, endpoint: string, apiKey: string) {
   });
 
   if (!response.ok) {
-    throw new Error(`Upload failed: ${response.status} ${response.statusText}`);
+    // statusText is always empty over HTTP/2, which worker.askhb.no serves, so
+    // on its own it renders as "Upload failed: 403 " with no reason at all.
+    const detail = await response.text().catch(() => '');
+    throw new Error(`Upload failed: ${response.status} ${detail || response.statusText || 'no response body'}`);
   }
 
   return response;


### PR DESCRIPTION
Item 3 from the review. All three only bite once a CV already exists, which is now the case.

**Removing mid-upload could resurrect the link.** The trash button had no `disabled` guard and `cvUrl` is not touched until an upload *succeeds*, so it stayed live for the whole upload. Removing mid-flight and letting the upload land called `onUpdate('cvUrl', …)` again and undid the removal — then said "Uploaded", inviting a Save that republished a CV the user had just removed. Uploads now take a ticket from a ref counter and only the newest may write state, and remove is disabled while one is in flight.

**A replaced PDF stayed invisible for up to 4 hours.** `cvUrl` was a fixed URL and `r2.askhb.no` serves `cv.pdf` with `max-age=14400` (observed `cf-cache-status: HIT`). It now carries `?v=<timestamp>`, so saving after a replace points the site at a URL the edge has never seen.

**"Press Save to publish the change" was false for a replace.** Every upload writes the same key, so once `cvUrl` points there the PUT *is* the publish. The message now says the file is already public and explains what Save actually does.

Also: upload failures rendered as `Upload failed: 403 ` with no reason, because `statusText` is always empty over HTTP/2. The response body is now included.

Verified in the browser with the worker PUT stubbed slow (nothing reached the bucket, nothing saved): mid-upload the trash button is disabled with "Wait for the upload to finish" and clicking it does nothing; the upload then lands with the link intact, the cache buster present, and the corrected message.